### PR TITLE
abi-tracker: Allow definining Date from profile version

### DIFF
--- a/abi-tracker.pl
+++ b/abi-tracker.pl
@@ -1576,8 +1576,12 @@ sub detectDate($)
     
     my $Source = $Profile->{"Versions"}{$V}{"Source"};
     my $Date = undef;
-    
-    if($V eq "current")
+
+    if (defined $Profile->{"Versions"}{$V}{"Date"})
+    {
+        $Date = $Profile->{"Versions"}{$V}{"Date"}
+    }
+    elsif($V eq "current")
     {
         if(defined $Profile->{"Git"})
         {


### PR DESCRIPTION
This way Date can be generated in the report if the Scm is not supported
or if a specific Date is wanted instead of the one provided by Scm.